### PR TITLE
Afedynitch/issue3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,10 +26,10 @@ packages = find:
 package_dir =
     = src
 include_package_data = True
-python_requires = >=3.7
+python_requires = >=3.8
 install_requires =
     numpy
-    scipy
+    scipy>=1.8.0
     rich
 
 [options.packages.find]

--- a/src/daemonflux/__init__.py
+++ b/src/daemonflux/__init__.py
@@ -6,7 +6,7 @@ import sys
 __version__ = version("daemonflux")
 __all__ = ["Flux", "__version__"]
 
-if int(scipy_version.split(".")[2]) < 8:
+if int(scipy_version.split(".")[1]) < 8:
     sys.modules["scipy.interpolate._fitpack2"] = sys.modules[
         "scipy.interpolate.fitpack2"
     ]

--- a/src/daemonflux/__init__.py
+++ b/src/daemonflux/__init__.py
@@ -1,5 +1,16 @@
 from daemonflux.flux import Flux
 from importlib.metadata import version
+from scipy.version import version as scipy_version
+import sys
 
 __version__ = version("daemonflux")
 __all__ = ["Flux", "__version__"]
+
+if int(scipy_version.split(".")[2]) < 8:
+    sys.modules["scipy.interpolate._fitpack2"] = sys.modules[
+        "scipy.interpolate.fitpack2"
+    ]
+    raise DeprecationWarning(
+        "scipy version must be >= 1.8.0. "
+        + "Support for lower version will be removed in future releases."
+    )

--- a/src/daemonflux/__init__.py
+++ b/src/daemonflux/__init__.py
@@ -1,7 +1,8 @@
+import sys
 from daemonflux.flux import Flux
 from importlib.metadata import version
 from scipy.version import version as scipy_version
-import sys
+import scipy.interpolate  # noqa: F401
 
 __version__ = version("daemonflux")
 __all__ = ["Flux", "__version__"]


### PR DESCRIPTION
Fixing #1. Python requirements bumped to 3.8 (which was the originally intended minimal version) and scipy 1.8+. Nonetheless a workaround for scipy <1.8 was added for manual installations.