### PR TITLE
Fix warning about open io handle when unpickling on some systems

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -24,8 +24,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        arch: [native, arm64]
-        py: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        # arch: [native, arm64]
+        py: ["3.8", "3.9", "3.10", "3.11", "3.12"]
       fail-fast: false
 
     steps:

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -23,23 +23,16 @@ jobs:
 
     strategy:
       matrix:
-        include:
-          # Python version number must be string, otherwise 3.10 becomes 3.1
-          - os: windows-latest
-            python-version: "3.10"
-
-          - os: macos-latest
-            python-version: "3.8"
-
-          - os: ubuntu-latest
-            python-version: "3.9"
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        arch: [native, arm64]
+        py: [cp 37, cp38, cp39, cp310, cp311, cp312]
       fail-fast: false
 
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: ${{ matrix.py }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         arch: [native, arm64]
-        py: [cp 37, cp38, cp39, cp310, cp311, cp312]
+        py: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
       fail-fast: false
 
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 # Standard hooks
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.5.0
+  rev: v4.6.0
   hooks:
   - id: check-case-conflict
   - id: check-docstring-first
@@ -18,14 +18,14 @@ repos:
 
 # Python formatting
 - repo: https://github.com/psf/black
-  rev: 24.3.0
+  rev: 24.4.2
   hooks:
   - id: black
 
 # Python linter (Flake8)
 - repo: https://github.com/pycqa/flake8
-  rev: 7.0.0
+  rev: 7.1.0
   hooks:
   - id: flake8
-    files: chromo/[^_].*\.py
+    files: ./[^_].*\.py
     args: [--config, setup.cfg]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = daemonflux
-version = 0.8.1
+version = 0.8.2
 author = Anatoli Fedynitch
 maintainer_email = afedynitch@gmail.com
 description = Tabulated representation of a muon-calibrated muon and neutrino flux model
@@ -18,6 +18,8 @@ classifiers =
         Programming Language :: Python :: 3.8
         Programming Language :: Python :: 3.9
         Programming Language :: Python :: 3.10
+        Programming Language :: Python :: 3.11
+        Programming Language :: Python :: 3.12
         License :: OSI Approved :: BSD License
         License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)
 

--- a/src/daemonflux/flux.py
+++ b/src/daemonflux/flux.py
@@ -203,14 +203,17 @@ class Flux:
         from copy import deepcopy
 
         assert pathlib.Path(spl_file).is_file(), f"Spline file {spl_file} not found."
-        (
-            known_pars,
-            self._fl_spl,
-            self._jac_spl,
-            cov,
-        ) = pickle.load(
-            open(spl_file, "rb")
-        )[:4]
+        with open(spl_file, "rb") as f:
+            if self._debug > 2:
+                print("Loading splines from", spl_file)
+            (
+                known_pars,
+                self._fl_spl,
+                self._jac_spl,
+                cov,
+            ) = pickle.load(
+                f
+            )[:4]
 
         known_parameters = []
         for k in known_pars:
@@ -235,8 +238,10 @@ class Flux:
             assert pathlib.Path(
                 cal_file
             ).is_file(), f"Calibration file {cal_file} not found."
-
-            calibration_d = pickle.load(open(str(cal_file), "rb"), encoding="latin1")
+            with open(str(cal_file), "rb") as f:
+                if self._debug > 2:
+                    print("Loading calibration from", cal_file)
+                calibration_d = pickle.load(f, encoding="latin1")
 
             param_values = []
             for ip, n in enumerate(known_parameters):


### PR DESCRIPTION
Some configurations seem to generate this warning:

```
/home/***/lib/python3.10/site-packages/daemonflux/flux.py:211: ResourceWarning: unclosed file <_io.BufferedReader name='/home/***/lib/python3.10/site-packages/daemonflux/data/daemonsplines_generic_202303_2.pkl'>
  ) = pickle.load(
ResourceWarning: Enable tracemalloc to get the object allocation traceback
```

This PR attempts to fix this by opening the file in a context manager. Also, some additional OS/Python combinations have been added and are tested.